### PR TITLE
Fix: Make Prisma client fully optional with dynamic imports for mock deployment

### DIFF
--- a/frontend/web/src/lib/prisma.ts
+++ b/frontend/web/src/lib/prisma.ts
@@ -4,12 +4,16 @@
  * DEPLOYMENT MODE: Mock Data (No Database)
  * This file safely handles Prisma when DATABASE_URL is not available.
  * For Vercel deployment with mock data, Prisma will gracefully fallback.
+ *
+ * IMPORTANT: This file uses dynamic imports to avoid build-time dependency on @prisma/client
+ * which may not be available in mock deployment environments.
  */
 
-import { PrismaClient } from '@prisma/client'
+// Type definition for Prisma client (without importing it)
+type PrismaClientType = any;
 
 // Mock Prisma client for deployment without database
-const createMockPrismaClient = () => {
+const createMockPrismaClient = (): PrismaClientType => {
   console.warn('⚠️ Prisma: DATABASE_URL not configured. Using mock data mode.');
 
   return new Proxy({} as any, {
@@ -22,15 +26,28 @@ const createMockPrismaClient = () => {
   });
 };
 
-const prismaClientSingleton = () => {
+const prismaClientSingleton = (): PrismaClientType => {
+  // If using mock data, always return mock client
+  if (process.env.NEXT_PUBLIC_USE_MOCK_DATA === 'true') {
+    return createMockPrismaClient();
+  }
+
   // Only create real Prisma client if DATABASE_URL exists
   if (!process.env.DATABASE_URL) {
     return createMockPrismaClient();
   }
 
-  return new PrismaClient({
-    log: ['query', 'error', 'warn'],
-  });
+  // Try to dynamically import PrismaClient (only when needed)
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const { PrismaClient } = require('@prisma/client');
+    return new PrismaClient({
+      log: ['query', 'error', 'warn'],
+    });
+  } catch (error) {
+    console.warn('⚠️ Prisma client not available. Using mock mode.', error);
+    return createMockPrismaClient();
+  }
 };
 
 declare const globalThis: {

--- a/vercel.json
+++ b/vercel.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
-  "buildCommand": "ls -la shared/prisma/ && ls -la shared/prisma/schema/ && bunx prisma generate --schema=shared/prisma/schema && cd frontend/web && bun run build",
+  "buildCommand": "cd frontend/web && bun run build",
   "github": {
     "silent": true
   },


### PR DESCRIPTION
- Remove static import of @prisma/client to avoid build-time TypeScript errors
- Use dynamic require() wrapped in try/catch for optional Prisma loading
- Always use mock client when NEXT_PUBLIC_USE_MOCK_DATA=true
- Simplify vercel.json build command (no Prisma generation needed)
- Follows CodingSOP.md Section 7.2 - Mock Deployment Patterns