### PR TITLE
Fix: Remove 'cd frontend/web' from build command - already in root directory

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
-  "buildCommand": "cd frontend/web && bun run build",
+  "buildCommand": "bun run build",
   "github": {
     "silent": true
   },


### PR DESCRIPTION
Vercel's Root Directory setting is 'frontend/web', so build command
is already executed from that directory. No need to cd again.