### PR TITLE
Marsha/backdeploy

### DIFF
--- a/backend/server_NestJS/Dockerfile
+++ b/backend/server_NestJS/Dockerfile
@@ -162,34 +162,27 @@ RUN bun install --production && \
     bun add @prisma/client@latest && \
     bun add -d prisma@latest
 
-# Generate Prisma Client BEFORE copying dist
-# This ensures the generated client is available when the app starts
-RUN bunx prisma generate --schema=../shared/prisma/schema
-
-# ============================================
-# Copy generated Prisma client from builder
-# ============================================
-# This ensures we have the exact same generated client that was used during build
-COPY --from=builder /app/node_modules/.prisma ./node_modules/.prisma
-COPY --from=builder /app/node_modules/@prisma ./node_modules/@prisma
-
 # ============================================
 # Copy built application from builder stage
 # ============================================
 # This copies the compiled JavaScript from the builder stage
 # We DON'T copy the entire backend folder (would include src/, tests/, etc.)
-# Cache buster: 2025-10-13-v4
+# Cache buster: 2025-10-13-v5
 # ============================================
 COPY --from=builder /app/dist ./dist
 
-# Debug: Verify what was actually copied
-RUN echo "=== DIST FOLDER CONTENTS AFTER COPY ===" && \
-    ls -laR /app/dist/ 2>&1 | tee /tmp/dist-debug.log && \
-    echo "=== SEARCHING FOR main.js ===" && \
-    find /app -name "main.js" -type f 2>&1 | tee -a /tmp/dist-debug.log && \
-    echo "=== CHECKING PRISMA CLIENT ===" && \
-    ls -la /app/node_modules/.prisma/client/ 2>&1 | tee -a /tmp/dist-debug.log && \
-    echo "=== DEBUG OUTPUT ===" && cat /tmp/dist-debug.log
+# ============================================
+# Generate Prisma Client AFTER copying dist
+# ============================================
+# This ensures the generated client matches the production environment
+RUN echo "=== Generating Prisma Client ===" && \
+    bunx prisma generate --schema=../shared/prisma/schema && \
+    echo "=== Verifying Prisma Client ===" && \
+    ls -la /app/node_modules/.prisma/client/ && \
+    echo "=== Checking node_modules structure ===" && \
+    ls -la /app/node_modules/@prisma/ && \
+    echo "=== Verifying imports will work ===" && \
+    node -e "const { PrismaClient } = require('@prisma/client'); console.log('✅ Prisma Client loaded successfully')"
 
 # ============================================
 # Expose Port 8080

--- a/backend/server_NestJS/Dockerfile
+++ b/backend/server_NestJS/Dockerfile
@@ -2,6 +2,7 @@
 # Multi-Stage Dockerfile for NestJS Backend
 # ============================================
 # This Dockerfile builds the NextPhoton NestJS backend for deployment on Fly.io
+# CACHE BUSTER: 2025-10-13-v2
 #
 # Architecture:
 # - Stage 1 (builder): Install dependencies, generate Prisma client, build NestJS app
@@ -157,6 +158,13 @@ RUN bun install --production
 # ============================================
 COPY --from=builder /app/dist ./dist
 
+# Debug: Verify what was actually copied
+RUN echo "=== DIST FOLDER CONTENTS AFTER COPY ===" && \
+    ls -laR /app/dist/ 2>&1 | tee /tmp/dist-debug.log && \
+    echo "=== SEARCHING FOR main.js ===" && \
+    find /app -name "main.js" -type f 2>&1 | tee -a /tmp/dist-debug.log && \
+    echo "=== DEBUG OUTPUT ===" && cat /tmp/dist-debug.log
+
 # ============================================
 # Copy shared Prisma schema (required for runtime)
 # ============================================
@@ -203,7 +211,7 @@ HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
 # ============================================
 # Why this command?
 # - Uses Node.js to run compiled JavaScript (faster startup than bun for NestJS)
-# - Runs from dist/backend/server_NestJS/src/main.js (monorepo structure)
+# - Runs from dist/backend/server_NestJS/src/main.js (monorepo structure includes shared)
 # - Your main.ts binds to 0.0.0.0:${PORT} (Fly.io will set PORT=8080)
 # ============================================
 CMD ["node", "dist/backend/server_NestJS/src/main.js"]

--- a/backend/server_NestJS/Dockerfile
+++ b/backend/server_NestJS/Dockerfile
@@ -98,7 +98,10 @@ COPY backend/server_NestJS/nest-cli.json* ./
 # ============================================
 # This compiles TypeScript to JavaScript in the dist/ folder
 # ============================================
-RUN bun run build
+RUN bun run build && \
+    echo "=== Listing dist directory structure ===" && \
+    ls -la dist/ && \
+    find dist -type f -name "*.js" | head -20
 
 # ============================================
 # Stage 2: Production Runner
@@ -200,7 +203,7 @@ HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
 # ============================================
 # Why this command?
 # - Uses Node.js to run compiled JavaScript (faster startup than bun for NestJS)
-# - Runs from dist/main.js (compiled entry point from src/main.ts)
+# - Runs from dist/backend/server_NestJS/src/main.js (monorepo structure)
 # - Your main.ts binds to 0.0.0.0:${PORT} (Fly.io will set PORT=8080)
 # ============================================
-CMD ["node", "dist/main.js"]
+CMD ["node", "dist/backend/server_NestJS/src/main.js"]

--- a/backend/server_NestJS/Dockerfile
+++ b/backend/server_NestJS/Dockerfile
@@ -72,6 +72,9 @@ RUN bun install
 # - Prisma generates type-safe database client from schema
 # - Must be generated BEFORE building NestJS app
 # ============================================
+# Create minimal package.json at root to satisfy Prisma's project root detection
+RUN echo '{"name":"workspace","private":true}' > /package.json
+
 # Install prisma and @prisma/client, then generate client
 # Note: Prisma 6.7.0+ supports multi-file schemas - all .prisma files in the schema directory are loaded
 RUN bun add -d prisma@latest && \
@@ -155,6 +158,9 @@ COPY --from=builder /app/../shared ../shared
 # - Need to regenerate with production dependencies only
 # - Ensures Prisma client works with production node_modules
 # ============================================
+# Create minimal package.json at root to satisfy Prisma's project root detection
+RUN echo '{"name":"workspace","private":true}' > /package.json
+
 RUN bun add -d prisma@latest && \
     bun add @prisma/client@latest && \
     bunx prisma generate --schema=../shared/prisma/schema

--- a/backend/server_NestJS/Dockerfile
+++ b/backend/server_NestJS/Dockerfile
@@ -98,8 +98,10 @@ COPY backend/server_NestJS/nest-cli.json* ./
 # Build NestJS Application
 # ============================================
 # This compiles TypeScript to JavaScript in the dist/ folder
+# Cache buster: 2025-10-13-v3
 # ============================================
-RUN bun run build && \
+RUN echo "Build starting at: $(date)" && \
+    bun run build && \
     echo "=== Listing dist directory structure ===" && \
     ls -la dist/ && \
     find dist -type f -name "*.js" | head -20
@@ -140,21 +142,43 @@ COPY --from=builder /app/package.json ./
 COPY --from=builder /app/bun.lock* ./
 
 # ============================================
-# Install ONLY production dependencies
+# Copy shared Prisma schema FIRST (required for Prisma install)
+# ============================================
+COPY --from=builder /app/../shared ../shared
+
+# ============================================
+# Install ONLY production dependencies + Prisma
 # ============================================
 # Why --production flag?
 # - Skips devDependencies (typescript, @nestjs/cli, etc.)
 # - Results in smaller node_modules folder
 # - Faster container startup
 # ============================================
-RUN bun install --production
+# Create minimal package.json at root to satisfy Prisma's project root detection
+RUN echo '{"name":"workspace","private":true}' > /package.json
+
+# Install production deps with Prisma packages
+RUN bun install --production && \
+    bun add @prisma/client@latest && \
+    bun add -d prisma@latest
+
+# Generate Prisma Client BEFORE copying dist
+# This ensures the generated client is available when the app starts
+RUN bunx prisma generate --schema=../shared/prisma/schema
 
 # ============================================
-# Copy built application from builder stage FIRST
+# Copy generated Prisma client from builder
 # ============================================
-# IMPORTANT: Copy dist BEFORE Prisma operations to prevent overwrites
+# This ensures we have the exact same generated client that was used during build
+COPY --from=builder /app/node_modules/.prisma ./node_modules/.prisma
+COPY --from=builder /app/node_modules/@prisma ./node_modules/@prisma
+
+# ============================================
+# Copy built application from builder stage
+# ============================================
 # This copies the compiled JavaScript from the builder stage
 # We DON'T copy the entire backend folder (would include src/, tests/, etc.)
+# Cache buster: 2025-10-13-v4
 # ============================================
 COPY --from=builder /app/dist ./dist
 
@@ -163,27 +187,9 @@ RUN echo "=== DIST FOLDER CONTENTS AFTER COPY ===" && \
     ls -laR /app/dist/ 2>&1 | tee /tmp/dist-debug.log && \
     echo "=== SEARCHING FOR main.js ===" && \
     find /app -name "main.js" -type f 2>&1 | tee -a /tmp/dist-debug.log && \
+    echo "=== CHECKING PRISMA CLIENT ===" && \
+    ls -la /app/node_modules/.prisma/client/ 2>&1 | tee -a /tmp/dist-debug.log && \
     echo "=== DEBUG OUTPUT ===" && cat /tmp/dist-debug.log
-
-# ============================================
-# Copy shared Prisma schema (required for runtime)
-# ============================================
-COPY --from=builder /app/../shared ../shared
-
-# ============================================
-# Generate Prisma Client in production stage
-# ============================================
-# Why generate again?
-# - Prisma client was generated in builder with ALL dependencies
-# - Need to regenerate with production dependencies only
-# - Ensures Prisma client works with production node_modules
-# ============================================
-# Create minimal package.json at root to satisfy Prisma's project root detection
-RUN echo '{"name":"workspace","private":true}' > /package.json
-
-RUN bun add -d prisma@latest && \
-    bun add @prisma/client@latest && \
-    bunx prisma generate --schema=../shared/prisma/schema
 
 # ============================================
 # Expose Port 8080
@@ -211,7 +217,7 @@ HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
 # ============================================
 # Why this command?
 # - Uses Node.js to run compiled JavaScript (faster startup than bun for NestJS)
-# - Runs from dist/backend/server_NestJS/src/main.js (monorepo structure includes shared)
+# - Runs from dist/app/src/main.js (TypeScript compiles to this path)
 # - Your main.ts binds to 0.0.0.0:${PORT} (Fly.io will set PORT=8080)
 # ============================================
-CMD ["node", "dist/backend/server_NestJS/src/main.js"]
+CMD ["node", "dist/app/src/main.js"]

--- a/backend/server_NestJS/Dockerfile
+++ b/backend/server_NestJS/Dockerfile
@@ -146,6 +146,15 @@ COPY --from=builder /app/bun.lock* ./
 RUN bun install --production
 
 # ============================================
+# Copy built application from builder stage FIRST
+# ============================================
+# IMPORTANT: Copy dist BEFORE Prisma operations to prevent overwrites
+# This copies the compiled JavaScript from the builder stage
+# We DON'T copy the entire backend folder (would include src/, tests/, etc.)
+# ============================================
+COPY --from=builder /app/dist ./dist
+
+# ============================================
 # Copy shared Prisma schema (required for runtime)
 # ============================================
 COPY --from=builder /app/../shared ../shared
@@ -164,14 +173,6 @@ RUN echo '{"name":"workspace","private":true}' > /package.json
 RUN bun add -d prisma@latest && \
     bun add @prisma/client@latest && \
     bunx prisma generate --schema=../shared/prisma/schema
-
-# ============================================
-# Copy built application from builder stage
-# ============================================
-# This copies the compiled JavaScript from the builder stage
-# We DON'T copy the entire backend folder (would include src/, tests/, etc.)
-# ============================================
-COPY --from=builder /app/dist ./dist
 
 # ============================================
 # Expose Port 8080

--- a/backend/server_NestJS/fly.toml
+++ b/backend/server_NestJS/fly.toml
@@ -21,5 +21,5 @@ primary_region = 'bom'
   cpu_kind = 'shared'
   cpus = 1
 
-[restart]
+[[restart]]
   policy = 'never'

--- a/backend/server_NestJS/fly.toml
+++ b/backend/server_NestJS/fly.toml
@@ -20,3 +20,6 @@ primary_region = 'bom'
   memory = '1gb'
   cpu_kind = 'shared'
   cpus = 1
+
+[restart]
+  policy = 'never'

--- a/backend/server_NestJS/nest-cli.json
+++ b/backend/server_NestJS/nest-cli.json
@@ -5,7 +5,9 @@
   "compilerOptions": {
     "deleteOutDir": true,
     "tsConfigPath": "./tsconfig.json",
-    "webpack": false
+    "webpack": false,
+    "assets": []
   },
-  "entryFile": "main"
+  "entryFile": "main",
+  "root": "."
 }

--- a/backend/server_NestJS/src/prisma/prisma.service.ts
+++ b/backend/server_NestJS/src/prisma/prisma.service.ts
@@ -1,5 +1,5 @@
 import { Injectable, OnModuleInit, OnModuleDestroy } from '@nestjs/common';
-import { prisma } from '../../../../shared/db/index';
+import { prisma } from '@shared/db/index';
 
 /**
  * Prisma Service for NestJS Server

--- a/backend/server_NestJS/tsconfig.json
+++ b/backend/server_NestJS/tsconfig.json
@@ -22,5 +22,11 @@
     }
   },
   "include": ["src/**/*"],
-  "exclude": ["node_modules", "dist"]
+  "exclude": [
+    "node_modules",
+    "dist",
+    "../../shared/prisma/seed.ts",
+    "../../shared/prisma/auth.ts",
+    "../../shared/db/test-connection.ts"
+  ]
 }

--- a/fly.toml.backend
+++ b/fly.toml.backend
@@ -1,0 +1,26 @@
+# fly.toml app configuration file generated for nextphoton on 2025-10-11T19:10:31+05:30
+#
+# See https://fly.io/docs/reference/configuration/ for information about how to use this file.
+#
+
+app = 'nextphoton'
+primary_region = 'bom'
+
+[build]
+  dockerfile = "backend/server_NestJS/Dockerfile"
+
+[http_service]
+  internal_port = 8080
+  force_https = true
+  auto_stop_machines = 'stop'
+  auto_start_machines = true
+  min_machines_running = 0
+  processes = ['app']
+
+[[vm]]
+  memory = '1gb'
+  cpu_kind = 'shared'
+  cpus = 1
+
+[[restart]]
+  policy = 'never'


### PR DESCRIPTION
Restructure Docker build to generate Prisma Client AFTER copying the
dist folder instead of before:

- Remove copying of pre-generated Prisma client from builder stage
- Generate Prisma Client fresh in production stage after dist is copied
- Add verification steps to ensure Prisma Client loads successfully
- Update cache buster to v5
- Simplify debug output to focus on Prisma Client verification

This ensures Prisma Client generation doesn't interfere with the dist
folder and verifies the client can be imported correctly.