### PR TITLE
Fix: Resolve module resolution and configuration for successful Fly.io deployment

### DIFF
--- a/backend/server_NestJS/Dockerfile
+++ b/backend/server_NestJS/Dockerfile
@@ -55,6 +55,9 @@ COPY bun.lock* ./
 # Note: Backend imports from @shared/* via TypeScript path mapping
 COPY shared ../shared
 
+# Create symlink so /shared can access /app/node_modules for module resolution
+RUN ln -s /app/node_modules /shared/node_modules
+
 # ============================================
 # Install ALL dependencies (including devDependencies)
 # ============================================
@@ -146,6 +149,10 @@ COPY --from=builder /app/bun.lock* ./
 # ============================================
 COPY --from=builder /app/../shared ../shared
 
+# Create symlink so /shared can access /app/node_modules for module resolution
+# Remove existing symlink if it exists from the builder stage
+RUN rm -f /shared/node_modules && ln -s /app/node_modules /shared/node_modules
+
 # ============================================
 # Install ONLY production dependencies + Prisma
 # ============================================
@@ -210,7 +217,7 @@ HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
 # ============================================
 # Why this command?
 # - Uses Node.js to run compiled JavaScript (faster startup than bun for NestJS)
-# - Runs from dist/app/src/main.js (TypeScript compiles to this path)
+# - Runs from dist/app/src/main.js (TypeScript compiles to this path in Docker)
 # - Your main.ts binds to 0.0.0.0:${PORT} (Fly.io will set PORT=8080)
 # ============================================
 CMD ["node", "dist/app/src/main.js"]

--- a/backend/server_NestJS/package.json
+++ b/backend/server_NestJS/package.json
@@ -22,6 +22,7 @@
     "seed:auth": "ts-node -r tsconfig-paths/register src/auth/seed-auth.ts"
   },
   "dependencies": {
+    "@as-integrations/express5": "^1.1.0",
     "@nestjs/apollo": "^13.1.0",
     "@nestjs/common": "^11.0.1",
     "@nestjs/config": "^3.2.3",
@@ -30,9 +31,11 @@
     "@nestjs/jwt": "^10.2.0",
     "@nestjs/passport": "^10.0.3",
     "@nestjs/platform-express": "^11.0.1",
+    "@prisma/client": "^6.8.2",
     "apollo-server-express": "^3.13.0",
     "class-transformer": "^0.5.1",
     "class-validator": "^0.14.2",
+    "dotenv": "^16.5.0",
     "graphql": "^16.11.0",
     "passport": "^0.7.0",
     "passport-jwt": "^4.0.1",
@@ -62,6 +65,7 @@
     "globals": "^16.0.0",
     "jest": "^29.7.0",
     "prettier": "^3.4.2",
+    "prisma": "^6.8.2",
     "source-map-support": "^0.5.21",
     "supertest": "^7.0.0",
     "ts-jest": "^29.2.5",

--- a/fly.toml.backend
+++ b/fly.toml.backend
@@ -9,6 +9,9 @@ primary_region = 'bom'
 [build]
   dockerfile = "backend/server_NestJS/Dockerfile"
 
+[env]
+  PORT = "8080"
+
 [http_service]
   internal_port = 8080
   force_https = true

--- a/shared/prisma/schema/schema.prisma
+++ b/shared/prisma/schema/schema.prisma
@@ -4,7 +4,6 @@
 
 generator client {
   provider = "prisma-client-js"
-  output   = "../../../node_modules/.prisma/client"
 }
 
 datasource db {


### PR DESCRIPTION
- Add symlinks in Dockerfile for /shared to access /app/node_modules
- Add missing dependencies: @as-integrations/express5, dotenv, @prisma/client
- Set explicit PORT=8080 in fly.toml.backend environment configuration
- Remove custom Prisma client output path to use default location
- Server now successfully listens on port 8080 on Fly.io deployment